### PR TITLE
Fix Str.Repeat If the number of repetitions is 0, an abnormal result will be returned.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased
+
+- Fix `Str.Repeat` If the number of repetitions is 0, an abnormal result will be returned. ([#202](https://github.com/CatLib/Core/issues/202) )
+
 ## [v1.4.0 (2019-03-20)](https://github.com/CatLib/Core/releases/tag/v1.4.0)
 
 **Added**

--- a/src/CatLib.Core.Tests/Support/Util/StrTests.cs
+++ b/src/CatLib.Core.Tests/Support/Util/StrTests.cs
@@ -83,6 +83,13 @@ namespace CatLib.API.Stl
         }
 
         [TestMethod]
+        public void TestStrRepeatZero()
+        {
+            var result = Str.Repeat("abc", 0);
+            Assert.AreEqual(string.Empty, result);
+        }
+
+        [TestMethod]
         public void TestStrShuffle()
         {
             var str = "helloworld";

--- a/src/CatLib.Core/Support/Util/Str.cs
+++ b/src/CatLib.Core/Support/Util/Str.cs
@@ -175,9 +175,9 @@ namespace CatLib
             Guard.Requires<ArgumentNullException>(str != null);
             Guard.Requires<ArgumentOutOfRangeException>(num >= 0);
 
-            if (num == 0)
+            if (num <= 0)
             {
-                return str;
+                return string.Empty;
             }
 
             var requested = new StringBuilder();


### PR DESCRIPTION
| Q | A |
|----|----|
| Branch? |  v1.4  |
| Bug fix? | Yes(#202 ) |
| New feature? | No |
| Deprecations? | No |
| Internal Changed? | No |
| Tests pass? | N/A |
| Doc pr? | No |

Fix Str.Repeat If the number of repetitions is 0, an abnormal result will be returned.
Now it will be returned `string.Empty`