### PR TITLE
Removed Arr.Flash method.

### DIFF
--- a/src/CatLib.Core.Tests/Support/Util/ArrTests.cs
+++ b/src/CatLib.Core.Tests/Support/Util/ArrTests.cs
@@ -751,19 +751,6 @@ namespace CatLib.Tests.Support.Util
         }
 
         [TestMethod]
-        public void TestEmptyFlash()
-        {
-            var data = new int[] { };
-            var isCall = false;
-            Arr.Flash(data, (i) => { }, (o) => { }, () =>
-            {
-                isCall = true;
-            });
-
-            Assert.AreEqual(true, isCall);
-        }
-
-        [TestMethod]
         public void TestCut()
         {
             var data = new char[] { '1', '2', '3', '4', '5' };

--- a/src/CatLib.Core/Support/Util/Arr.cs
+++ b/src/CatLib.Core/Support/Util/Arr.cs
@@ -711,45 +711,6 @@ namespace CatLib
         }
 
         /// <summary>
-        /// A temporary callback element that rolls back element callbacks
-        /// if an exception is encountered or a callback is completed.
-        /// </summary>
-        /// <typeparam name="T">The type of array.</typeparam>
-        /// <param name="source">The specified array.</param>
-        /// <param name="process">The order callback.</param>
-        /// <param name="completed">After all callbacks are completed.</param>
-        /// <param name="rollback">Rollback callback.</param>
-        public static void Flash<T>(T[] source, Action<T> process, Action<T> rollback, Action completed)
-        {
-            Guard.Requires<ArgumentNullException>(source != null);
-
-            if (source.Length <= 0)
-            {
-                completed.Invoke();
-                return;
-            }
-
-            var index = 0;
-            try
-            {
-                foreach (var result in source)
-                {
-                    ++index;
-                    process.Invoke(result);
-                }
-
-                completed();
-            }
-            finally
-            {
-                while (--index >= 0)
-                {
-                    rollback.Invoke(source[index]);
-                }
-            }
-        }
-
-        /// <summary>
         /// Pass the specified array to the callback test.
         /// <para>The function returns false only if all elements pass the checker are false.</para>
         /// </summary>


### PR DESCRIPTION
| Q | A |
|----|----|
| Branch? |  v2.0(master)  |
| Bug fix? | No |
| New feature? | No |
| Deprecations? | No |
| Internal Changed? | No |
| Removed | Yes |
| Tests pass? | Yes |
| Doc pr? | No |

This submission removes the Arr.Flash method. Because this API looks bad smell.