### PR TITLE
Change IVariant to VariantAttribute.

### DIFF
--- a/src/CatLib.Core.Tests/Support/Container/ContainerTests.cs
+++ b/src/CatLib.Core.Tests/Support/Container/ContainerTests.cs
@@ -1994,7 +1994,8 @@ namespace CatLib.Tests.Stl
             });
         }
 
-        public class VariantModel : IVariant
+        [Variant]
+        public class VariantModel
         {
             public int num;
             public VariantModel(int num)

--- a/src/CatLib.Core/Support/Container/Container.cs
+++ b/src/CatLib.Core/Support/Container/Container.cs
@@ -865,7 +865,7 @@ namespace CatLib
                     return true;
                 }
 
-                if (IsBasicType(result.GetType()) && typeof(IVariant).IsAssignableFrom(conversionType))
+                if (IsBasicType(result.GetType()) && conversionType.IsDefined(typeof(VariantAttribute), false))
                 {
                     try
                     {

--- a/src/CatLib.Core/Support/Container/VariantAttribute.cs
+++ b/src/CatLib.Core/Support/Container/VariantAttribute.cs
@@ -9,13 +9,15 @@
  * Document: https://catlib.io/
  */
 
+using System;
+
 namespace CatLib
 {
     /// <summary>
-    /// 可转变的
-    /// <para>实现该接口的类，允许依赖注入容器将用户传入的基本类型(包含string)转变为目标类</para>
+    /// A constructor that represents the class allows a primitive type(Include string) to be passed in to be converted to the current class.
     /// </summary>
-    public interface IVariant
+    [AttributeUsage(AttributeTargets.Class)]
+    public class VariantAttribute : Attribute
     {
     }
 }


### PR DESCRIPTION
| Q | A |
|----|----|
| Branch? |  v2.0(master)  |
| Bug fix? | No |
| New feature? | No |
| Deprecations? | No |
| Internal Changed? | Yes |
| Removed | No |
| Tests pass? | Yes |
| Doc pr? | No |

The submission changes `IVariant` to an `VariantAttribute`.  Because empty interfaces are not recommended in the guide.