### PR TITLE
Removed Str.Encoding

### DIFF
--- a/src/CatLib.Core.Tests/Support/Stream/CombineStreamTests.cs
+++ b/src/CatLib.Core.Tests/Support/Stream/CombineStreamTests.cs
@@ -12,6 +12,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
+using System.Text;
 
 #pragma warning disable CA1034
 
@@ -20,6 +21,8 @@ namespace CatLib.Support.Tests
     [TestClass]
     public class CombineStreamTests
     {
+        public Encoding Encoding => Encoding.Default;
+
         [TestMethod]
         public void TestCombineStream()
         {
@@ -39,9 +42,9 @@ namespace CatLib.Support.Tests
 
             var buffer = new byte[5];
             Assert.AreEqual(5, stream.Read(buffer, 0, 5));
-            Assert.AreEqual("hello", Str.Encoding.GetString(buffer));
+            Assert.AreEqual("hello", Encoding.GetString(buffer));
             Assert.AreEqual(5, stream.Read(buffer, 0, 5));
-            Assert.AreEqual("world", Str.Encoding.GetString(buffer));
+            Assert.AreEqual("world", Encoding.GetString(buffer));
         }
 
         [TestMethod]
@@ -53,20 +56,20 @@ namespace CatLib.Support.Tests
 
             var buffer = new byte[5];
             Assert.AreEqual(5, stream.Read(buffer, 0, 5));
-            Assert.AreEqual("hello", Str.Encoding.GetString(buffer));
+            Assert.AreEqual("hello", Encoding.GetString(buffer));
             Assert.AreEqual(5, stream.Read(buffer, 0, 5));
-            Assert.AreEqual("world", Str.Encoding.GetString(buffer));
+            Assert.AreEqual("world", Encoding.GetString(buffer));
 
             stream.Seek(5, SeekOrigin.Begin);
             Assert.AreEqual(5, stream.Read(buffer, 0, 5));
-            Assert.AreEqual("world", Str.Encoding.GetString(buffer));
+            Assert.AreEqual("world", Encoding.GetString(buffer));
 
             stream.Seek(4, SeekOrigin.Begin);
             Assert.AreEqual(5, stream.Read(buffer, 0, 5));
-            Assert.AreEqual("oworl", Str.Encoding.GetString(buffer));
+            Assert.AreEqual("oworl", Encoding.GetString(buffer));
             stream.Seek(6, SeekOrigin.Begin);
             Assert.AreEqual(4, stream.Read(buffer, 0, 5));
-            Assert.AreEqual("orld", Str.Encoding.GetString(buffer, 0, 4));
+            Assert.AreEqual("orld", Encoding.GetString(buffer, 0, 4));
             stream.Seek(10, SeekOrigin.Begin);
             Assert.AreEqual(0, stream.Read(buffer, 0, 5));
             Assert.AreEqual(0, stream.Read(buffer, 0, 5));
@@ -81,13 +84,13 @@ namespace CatLib.Support.Tests
 
             var buffer = new byte[5];
             Assert.AreEqual(5, stream.Read(buffer, 0, 5));
-            Assert.AreEqual("hello", Str.Encoding.GetString(buffer));
+            Assert.AreEqual("hello", Encoding.GetString(buffer));
             stream.Seek(2, SeekOrigin.Current);
             Assert.AreEqual(3, stream.Read(buffer, 0, 5));
-            Assert.AreEqual("rld", Str.Encoding.GetString(buffer, 0, 3));
+            Assert.AreEqual("rld", Encoding.GetString(buffer, 0, 3));
             stream.Seek(-3, SeekOrigin.End);
             Assert.AreEqual(3, stream.Read(buffer, 0, 5));
-            Assert.AreEqual("rld", Str.Encoding.GetString(buffer, 0, 3));
+            Assert.AreEqual("rld", Encoding.GetString(buffer, 0, 3));
         }
 
         [TestMethod]
@@ -99,12 +102,12 @@ namespace CatLib.Support.Tests
 
             var buffer = new byte[5];
             Assert.AreEqual(5, stream.Read(buffer, 0, 5));
-            Assert.AreEqual("hello", Str.Encoding.GetString(buffer));
+            Assert.AreEqual("hello", Encoding.GetString(buffer));
 
             Assert.AreEqual(5, stream.Position);
             stream.Position = 0;
             Assert.AreEqual(5, stream.Read(buffer, 0, 5));
-            Assert.AreEqual("hello", Str.Encoding.GetString(buffer));
+            Assert.AreEqual("hello", Encoding.GetString(buffer));
         }
 
         [TestMethod]

--- a/src/CatLib.Core.Tests/Support/Stream/SegmentStreamTests.cs
+++ b/src/CatLib.Core.Tests/Support/Stream/SegmentStreamTests.cs
@@ -12,12 +12,15 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
+using System.Text;
 
 namespace CatLib.Support.Tests
 {
     [TestClass]
     public class SegmentStreamTests
     {
+        public Encoding Encoding => Encoding.Default;
+
         [TestMethod]
         public void TestRead()
         {
@@ -101,7 +104,7 @@ namespace CatLib.Support.Tests
             var segmentStream = new SegmentStream(baseStream, 11);
             var buffer = new byte[255];
             Assert.AreEqual(11, segmentStream.Read(buffer, 0, 255));
-            Assert.AreEqual("hello world", Str.Encoding.GetString(buffer, 0, 11));
+            Assert.AreEqual("hello world", Encoding.GetString(buffer, 0, 11));
         }
 
         [TestMethod]
@@ -111,7 +114,7 @@ namespace CatLib.Support.Tests
             var segmentStream = new SegmentStream(baseStream, 11);
             var buffer = new byte[255];
             Assert.AreEqual(11, segmentStream.Read(buffer, 0, 255));
-            Assert.AreEqual("hello world", Str.Encoding.GetString(buffer, 0, 11));
+            Assert.AreEqual("hello world", Encoding.GetString(buffer, 0, 11));
             Assert.AreEqual(0, segmentStream.Read(buffer, 0, 255));
         }
 
@@ -122,7 +125,7 @@ namespace CatLib.Support.Tests
             var segmentStream = new SegmentStream(baseStream, 11);
             var buffer = new byte[5];
             Assert.AreEqual(5, segmentStream.Read(buffer, 0, 5));
-            Assert.AreEqual("hello", Str.Encoding.GetString(buffer, 0, 5));
+            Assert.AreEqual("hello", Encoding.GetString(buffer, 0, 5));
         }
 
         [TestMethod]
@@ -140,7 +143,7 @@ namespace CatLib.Support.Tests
         {
             var baseStream = "hello world , my name is miaomiao".ToStream();
             var segmentStream = new SegmentStream(baseStream, 11);
-            var buffer = Str.Encoding.GetBytes("hello world");
+            var buffer = Encoding.GetBytes("hello world");
 
             segmentStream.Write(buffer, 0, buffer.Length);
         }

--- a/src/CatLib.Core/Support/Extension/ExtendStream.cs
+++ b/src/CatLib.Core/Support/Extension/ExtendStream.cs
@@ -87,7 +87,7 @@ namespace CatLib.Support
                     throw new LogicException($"Can not read stream, {nameof(source.CanRead)} == false");
                 }
 
-                encoding = encoding ?? Str.Encoding;
+                encoding = encoding ?? Encoding.Default;
                 var memoryStream = source as MemoryStream;
                 if (memoryStream != null)
                 {

--- a/src/CatLib.Core/Support/Extension/ExtendString.cs
+++ b/src/CatLib.Core/Support/Extension/ExtendString.cs
@@ -27,7 +27,7 @@ namespace CatLib.Support
         /// <returns>The stream instance.</returns>
         public static Stream ToStream(this string str, Encoding encoding = null)
         {
-            return new MemoryStream((encoding ?? Str.Encoding).GetBytes(str));
+            return new MemoryStream((encoding ?? Encoding.Default).GetBytes(str));
         }
     }
 }

--- a/src/CatLib.Core/Support/Str.cs
+++ b/src/CatLib.Core/Support/Str.cs
@@ -47,11 +47,6 @@ namespace CatLib.Support
         }
 
         /// <summary>
-        /// Gets or sets string encoding.
-        /// </summary>
-        public static Encoding Encoding { get; set; } = Encoding.UTF8;
-
-        /// <summary>
         /// Get the function name expressed by the string.
         /// </summary>
         /// <param name="pattern">The string.</param>


### PR DESCRIPTION
| Q | A |
|----|----|
| Branch? |  v2.0(master)  |
| Bug fix? | No |
| New feature? | No |
| Deprecations? | No |
| Internal Changed? | Yes |
| Removed | No |
| Tests pass? | Yes |
| Doc pr? | No |

This commit removes the definition of `Str.Encoding` because we don't want to control global Encoding through a static object.