### PR TITLE
Move the exception namespace.

### DIFF
--- a/src/CatLib.Core.Tests/CatLib/TestsApplication.cs
+++ b/src/CatLib.Core.Tests/CatLib/TestsApplication.cs
@@ -11,6 +11,7 @@
 
 using CatLib.Container;
 using CatLib.EventDispatcher;
+using CatLib.Exception;
 using CatLib.Support;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;

--- a/src/CatLib.Core.Tests/Container/TestsBindData.cs
+++ b/src/CatLib.Core.Tests/Container/TestsBindData.cs
@@ -10,6 +10,7 @@
  */
 
 using CatLib.Container;
+using CatLib.Exception;
 using CatLib.Support;
 using CatLib.Tests.Fixture;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/CatLib.Core.Tests/Container/TestsContainer.cs
+++ b/src/CatLib.Core.Tests/Container/TestsContainer.cs
@@ -10,13 +10,14 @@
  */
 
 using CatLib.Container;
-using CatLib.Support;
+using CatLib.Exception;
 using CatLib.Tests.Fixture;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using CContainer = CatLib.Container.Container;
+using SException = System.Exception;
 
 namespace CatLib.Tests.Container
 {
@@ -248,12 +249,12 @@ namespace CatLib.Tests.Container
                 container.Alias(alias, service);
                 Assert.Fail(reason);
             }
-            catch (Exception ex) when (ex.GetType() != expected)
+            catch (SException ex) when (ex.GetType() != expected)
             {
                 Assert.Fail($"Expected throw an exception: {expected}, actual throw: {ex}");
             }
 #pragma warning disable CA1031
-            catch (Exception)
+            catch (SException)
 #pragma warning restore CA1031
             {
                 // test passed.

--- a/src/CatLib.Core.Tests/Container/TestsExtendContainer.cs
+++ b/src/CatLib.Core.Tests/Container/TestsExtendContainer.cs
@@ -10,6 +10,7 @@
  */
 
 using CatLib.Container;
+using CatLib.Exception;
 using CatLib.Support;
 using CatLib.Tests.Fixture;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/CatLib.Core.Tests/EventDispatcher/TestsEventDispatcher.cs
+++ b/src/CatLib.Core.Tests/EventDispatcher/TestsEventDispatcher.cs
@@ -9,6 +9,7 @@
  * Document: https://catlib.io/
  */
 
+using CatLib.Exception;
 using CatLib.Support;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;

--- a/src/CatLib.Core.Tests/Framework/ExpectedExceptionAndMessageAttribute.cs
+++ b/src/CatLib.Core.Tests/Framework/ExpectedExceptionAndMessageAttribute.cs
@@ -11,6 +11,7 @@
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using SException = System.Exception;
 
 namespace CatLib.Tests
 {
@@ -36,7 +37,7 @@ namespace CatLib.Tests
             this.strict = strict;
         }
 
-        protected override void Verify(Exception exception)
+        protected override void Verify(SException exception)
         {
             Assert.IsNotNull(exception);
 

--- a/src/CatLib.Core.Tests/Framework/TestException.cs
+++ b/src/CatLib.Core.Tests/Framework/TestException.cs
@@ -11,10 +11,11 @@
 
 using System;
 using System.Runtime.Serialization;
+using SException = System.Exception;
 
 namespace CatLib.Tests
 {
-    public class TestException : Exception
+    public class TestException : SException
     {
         public TestException()
         {
@@ -25,7 +26,7 @@ namespace CatLib.Tests
         {
         }
 
-        public TestException(string message, Exception innerException)
+        public TestException(string message, SException innerException)
             : base(message, innerException)
         {
         }

--- a/src/CatLib.Core.Tests/Support/Stream/TestsRingBuffer.cs
+++ b/src/CatLib.Core.Tests/Support/Stream/TestsRingBuffer.cs
@@ -9,6 +9,7 @@
  * Document: https://catlib.io/
  */
 
+using CatLib.Exception;
 using CatLib.Support;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;

--- a/src/CatLib.Core.Tests/Support/TestsGuard.cs
+++ b/src/CatLib.Core.Tests/Support/TestsGuard.cs
@@ -14,6 +14,7 @@
 using CatLib.Support;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using SException = System.Exception;
 
 namespace CatLib.Tests.Support
 {
@@ -23,14 +24,14 @@ namespace CatLib.Tests.Support
         [TestMethod]
         public void TestRequires()
         {
-            var innerException = new Exception("inner exception");
+            var innerException = new SException("inner exception");
 
             try
             {
-                Guard.Requires<Exception>(false, "foo", innerException);
+                Guard.Requires<SException>(false, "foo", innerException);
                 Assert.Fail();
             }
-            catch (Exception ex)
+            catch (SException ex)
             {
                 Assert.AreEqual("foo", ex.Message);
                 Assert.AreEqual("inner exception", ex.InnerException.Message);
@@ -40,7 +41,7 @@ namespace CatLib.Tests.Support
         [TestMethod]
         public void TestExtend()
         {
-            var innerException = new Exception("inner exception");
+            var innerException = new SException("inner exception");
 
             Guard.Extend<ArgumentNullException>((messgae, inner, state) =>
             {
@@ -52,7 +53,7 @@ namespace CatLib.Tests.Support
                 Guard.Requires<ArgumentNullException>(false, null, innerException);
                 Assert.Fail();
             }
-            catch (Exception ex)
+            catch (SException ex)
             {
                 Assert.AreEqual("foo", ex.Message);
                 Assert.AreEqual("inner exception", ex.InnerException.Message);
@@ -62,14 +63,14 @@ namespace CatLib.Tests.Support
         [TestMethod]
         public void TestRequireNotBaseException()
         {
-            var innerException = new Exception("inner exception");
+            var innerException = new SException("inner exception");
 
             try
             {
                 Guard.Requires<ArgumentNullException>(false, "foo", innerException);
                 Assert.Fail();
             }
-            catch (Exception ex)
+            catch (SException ex)
             {
                 Assert.AreEqual("foo", ex.Message);
                 Assert.AreEqual("inner exception", ex.InnerException.Message);

--- a/src/CatLib.Core/CatLib/Application.cs
+++ b/src/CatLib.Core/CatLib/Application.cs
@@ -11,20 +11,20 @@
 
 using CatLib.Container;
 using CatLib.EventDispatcher;
+using CatLib.Exception;
 using CatLib.Support;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
-using CatLibContainer = CatLib.Container.Container;
 
 namespace CatLib
 {
     /// <summary>
     /// The CatLib <see cref="Application"/> instance.
     /// </summary>
-    public class Application : CatLibContainer, IApplication
+    public class Application : Container.Container, IApplication
     {
         private static string version;
         private readonly IList<IServiceProvider> loadedProviders;

--- a/src/CatLib.Core/CatLib/Facade.cs
+++ b/src/CatLib.Core/CatLib/Facade.cs
@@ -10,7 +10,6 @@
  */
 
 #pragma warning disable CA1000
-#pragma warning disable S3963
 #pragma warning disable S2743
 #pragma warning disable S1118
 
@@ -36,7 +35,9 @@ namespace CatLib
         /// <summary>
         /// Initializes static members of the <see cref="Facade{TService}"/> class.
         /// </summary>
+#pragma warning disable S3963
         static Facade()
+#pragma warning restore S3963
         {
             Service = App.Type2Service(typeof(TService));
             App.OnNewApplication += app =>

--- a/src/CatLib.Core/Container/BindData.cs
+++ b/src/CatLib.Core/Container/BindData.cs
@@ -9,6 +9,7 @@
  * Document: https://catlib.io/
  */
 
+using CatLib.Exception;
 using CatLib.Support;
 using System;
 using System.Collections.Generic;

--- a/src/CatLib.Core/Container/Bindable.cs
+++ b/src/CatLib.Core/Container/Bindable.cs
@@ -9,6 +9,7 @@
  * Document: https://catlib.io/
  */
 
+using CatLib.Exception;
 using CatLib.Support;
 using System;
 using System.Collections.Generic;

--- a/src/CatLib.Core/Container/Container.cs
+++ b/src/CatLib.Core/Container/Container.cs
@@ -9,12 +9,14 @@
  * Document: https://catlib.io/
  */
 
+using CatLib.Exception;
 using CatLib.Support;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Text;
+using SException = System.Exception;
 
 namespace CatLib.Container
 {
@@ -995,7 +997,7 @@ namespace CatLib.Container
                         return true;
                     }
 #pragma warning disable CA1031
-                    catch (Exception)
+                    catch (SException)
 #pragma warning restore CA1031
                     {
                         // ignored
@@ -1010,7 +1012,7 @@ namespace CatLib.Container
                 }
             }
 #pragma warning disable CA1031
-            catch (Exception)
+            catch (SException)
 #pragma warning restore CA1031
             {
                 // ignored
@@ -1258,7 +1260,7 @@ namespace CatLib.Container
         /// <param name="makeServiceType">The <see cref="Make"/> service type.</param>
         /// <param name="innerException">The inner exception.</param>
         /// <returns>The resolve failure exception instance.</returns>
-        protected virtual UnresolvableException MakeBuildFaildException(string makeService, Type makeServiceType, Exception innerException)
+        protected virtual UnresolvableException MakeBuildFaildException(string makeService, Type makeServiceType, SException innerException)
         {
             var message = makeServiceType != null
                 ? $"Class [{makeServiceType}] build faild. Service is [{makeService}]."
@@ -1274,7 +1276,7 @@ namespace CatLib.Container
         /// </summary>
         /// <param name="innerException">The inner exception.</param>
         /// <returns>The debug message.</returns>
-        protected virtual string GetInnerExceptionMessage(Exception innerException)
+        protected virtual string GetInnerExceptionMessage(SException innerException)
         {
             if (innerException == null)
             {
@@ -1522,7 +1524,7 @@ namespace CatLib.Container
                     return GetDependencies(makeServiceBindData, constructor.GetParameters(), userParams);
                 }
 #pragma warning disable CA1031
-                catch (Exception ex)
+                catch (SException ex)
                 {
                     if (exceptionDispatchInfo == null)
                     {
@@ -1681,11 +1683,11 @@ namespace CatLib.Container
                 return CreateInstance(makeServiceType, userParams);
             }
 #pragma warning disable CA1031
-            catch (Exception ex)
+            catch (SException ex)
+#pragma warning restore CA1031
             {
                 throw MakeBuildFaildException(makeServiceBindData.Service, makeServiceType, ex);
             }
-#pragma warning restore CA1031
         }
 
         /// <inheritdoc cref="CreateInstance(Bindable, Type, object[])"/>

--- a/src/CatLib.Core/Container/ExtendContainer.cs
+++ b/src/CatLib.Core/Container/ExtendContainer.cs
@@ -11,6 +11,7 @@
 
 #pragma warning disable SA1618
 
+using CatLib.Exception;
 using CatLib.Support;
 using System;
 

--- a/src/CatLib.Core/Container/MethodContainer.cs
+++ b/src/CatLib.Core/Container/MethodContainer.cs
@@ -9,6 +9,7 @@
  * Document: https://catlib.io/
  */
 
+using CatLib.Exception;
 using CatLib.Support;
 using System;
 using System.Collections.Generic;

--- a/src/CatLib.Core/Container/UnresolvableException.cs
+++ b/src/CatLib.Core/Container/UnresolvableException.cs
@@ -9,9 +9,9 @@
  * Document: https://catlib.io/
  */
 
-using CatLib.Support;
-using System;
+using CatLib.Exception;
 using System.Diagnostics.CodeAnalysis;
+using SException = System.Exception;
 
 namespace CatLib.Container
 {
@@ -42,7 +42,7 @@ namespace CatLib.Container
         /// </summary>
         /// <param name="message">The exception message.</param>
         /// <param name="innerException">The inner exception.</param>
-        public UnresolvableException(string message, Exception innerException)
+        public UnresolvableException(string message, SException innerException)
             : base(message, innerException)
         {
         }

--- a/src/CatLib.Core/EventDispatcher/EventDispatcher.cs
+++ b/src/CatLib.Core/EventDispatcher/EventDispatcher.cs
@@ -9,6 +9,7 @@
  * Document: https://catlib.io/
  */
 
+using CatLib.Exception;
 using CatLib.Support;
 using System;
 using System.Collections.Generic;

--- a/src/CatLib.Core/Exception/AssertException.cs
+++ b/src/CatLib.Core/Exception/AssertException.cs
@@ -9,11 +9,11 @@
  * Document: https://catlib.io/
  */
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
+using SException = System.Exception;
 
-namespace CatLib.Support
+namespace CatLib.Exception
 {
     /// <summary>
     /// Represents an assertion exception.
@@ -42,7 +42,7 @@ namespace CatLib.Support
         /// </summary>
         /// <param name="message">The exception message.</param>
         /// <param name="innerException">The inner exception.</param>
-        public AssertException(string message, Exception innerException)
+        public AssertException(string message, SException innerException)
             : base(message, innerException)
         {
         }

--- a/src/CatLib.Core/Exception/LogicException.cs
+++ b/src/CatLib.Core/Exception/LogicException.cs
@@ -9,48 +9,51 @@
  * Document: https://catlib.io/
  */
 
-using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
+using SException = System.Exception;
 
-namespace CatLib.Support
+namespace CatLib.Exception
 {
     /// <summary>
-    /// Represents a generic runtime exception.
+    /// Represents a logical exception encountered during execution.
     /// </summary>
-    public class RuntimeException : Exception
+    /// <remarks>Logical exceptions are caused by logical errors during runtime.</remarks>
+    [ExcludeFromCodeCoverage]
+    public class LogicException : RuntimeException
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="RuntimeException"/> class.
+        /// Initializes a new instance of the <see cref="LogicException"/> class.
         /// </summary>
-        public RuntimeException()
+        public LogicException()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RuntimeException"/> class.
+        /// Initializes a new instance of the <see cref="LogicException"/> class.
         /// </summary>
         /// <param name="message">The exception message.</param>
-        public RuntimeException(string message)
+        public LogicException(string message)
             : base(message)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RuntimeException"/> class.
+        /// Initializes a new instance of the <see cref="LogicException"/> class.
         /// </summary>
         /// <param name="message">The exception message.</param>
         /// <param name="innerException">The inner exception.</param>
-        public RuntimeException(string message, Exception innerException)
+        public LogicException(string message, SException innerException)
             : base(message, innerException)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RuntimeException"/> class.
+        /// Initializes a new instance of the <see cref="LogicException"/> class.
         /// </summary>
         /// <param name="serializationInfo">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="streamingContext">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
-        protected RuntimeException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        protected LogicException(SerializationInfo serializationInfo, StreamingContext streamingContext)
             : base(serializationInfo, streamingContext)
         {
         }

--- a/src/CatLib.Core/Exception/RuntimeException.cs
+++ b/src/CatLib.Core/Exception/RuntimeException.cs
@@ -9,51 +9,48 @@
  * Document: https://catlib.io/
  */
 
-using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
+using SException = System.Exception;
 
-namespace CatLib.Support
+namespace CatLib.Exception
 {
     /// <summary>
-    /// Represents a logical exception encountered during execution.
+    /// Represents a generic runtime exception.
     /// </summary>
-    /// <remarks>Logical exceptions are caused by logical errors during runtime.</remarks>
-    [ExcludeFromCodeCoverage]
-    public class LogicException : RuntimeException
+    public class RuntimeException : SException
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="LogicException"/> class.
+        /// Initializes a new instance of the <see cref="RuntimeException"/> class.
         /// </summary>
-        public LogicException()
+        public RuntimeException()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LogicException"/> class.
+        /// Initializes a new instance of the <see cref="RuntimeException"/> class.
         /// </summary>
         /// <param name="message">The exception message.</param>
-        public LogicException(string message)
+        public RuntimeException(string message)
             : base(message)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LogicException"/> class.
+        /// Initializes a new instance of the <see cref="RuntimeException"/> class.
         /// </summary>
         /// <param name="message">The exception message.</param>
         /// <param name="innerException">The inner exception.</param>
-        public LogicException(string message, Exception innerException)
+        public RuntimeException(string message, SException innerException)
             : base(message, innerException)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LogicException"/> class.
+        /// Initializes a new instance of the <see cref="RuntimeException"/> class.
         /// </summary>
         /// <param name="serializationInfo">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="streamingContext">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
-        protected LogicException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        protected RuntimeException(SerializationInfo serializationInfo, StreamingContext streamingContext)
             : base(serializationInfo, streamingContext)
         {
         }

--- a/src/CatLib.Core/Support/Arr.cs
+++ b/src/CatLib.Core/Support/Arr.cs
@@ -9,6 +9,7 @@
  * Document: https://catlib.io/
  */
 
+using CatLib.Exception;
 using System;
 using System.Collections.Generic;
 

--- a/src/CatLib.Core/Support/Extension/ExtendStream.cs
+++ b/src/CatLib.Core/Support/Extension/ExtendStream.cs
@@ -9,6 +9,7 @@
  * Document: https://catlib.io/
  */
 
+using CatLib.Exception;
 using System;
 using System.IO;
 using System.Text;

--- a/src/CatLib.Core/Support/Guard.cs
+++ b/src/CatLib.Core/Support/Guard.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using SException = System.Exception;
 
 namespace CatLib.Support
 {
@@ -21,7 +22,7 @@ namespace CatLib.Support
     public sealed class Guard
     {
         private static Guard that;
-        private static IDictionary<Type, Func<string, Exception, object, Exception>> exceptionFactory;
+        private static IDictionary<Type, Func<string, SException, object, SException>> exceptionFactory;
 
         /// <summary>
         /// Gets the singleton instance of the Guard functionality.
@@ -49,8 +50,8 @@ namespace CatLib.Support
         /// <param name="innerException">The exception that is the cause of the current exception, or a null reference.</param>
         /// <param name="state">State will be passed to the registered exception build factory.</param>
         [System.Diagnostics.DebuggerNonUserCode]
-        public static void Requires<TException>(bool condition, string message = null, Exception innerException = null, object state = null)
-            where TException : Exception, new()
+        public static void Requires<TException>(bool condition, string message = null, SException innerException = null, object state = null)
+            where TException : SException, new()
         {
             Requires(typeof(TException), condition, message, innerException, state);
         }
@@ -64,7 +65,7 @@ namespace CatLib.Support
         /// <param name="innerException">The exception that is the cause of the current exception, or a null reference.</param>
         /// <param name="state">State will be passed to the registered exception build factory.</param>
         [System.Diagnostics.DebuggerNonUserCode]
-        public static void Requires(Type exception, bool condition, string message = null, Exception innerException = null, object state = null)
+        public static void Requires(Type exception, bool condition, string message = null, SException innerException = null, object state = null)
         {
             if (condition)
             {
@@ -82,7 +83,7 @@ namespace CatLib.Support
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception, or a null reference.</param>
         [System.Diagnostics.DebuggerNonUserCode]
-        public static void ParameterNotNull(object argumentValue, string argumentName, string message = null, Exception innerException = null)
+        public static void ParameterNotNull(object argumentValue, string argumentName, string message = null, SException innerException = null)
         {
             if (argumentValue != null)
             {
@@ -106,7 +107,7 @@ namespace CatLib.Support
         /// <typeparam name="T">The type of exception.</typeparam>
         /// <param name="factory">The exception factory.</param>
         [System.Diagnostics.DebuggerNonUserCode]
-        public static void Extend<T>(Func<string, Exception, object, Exception> factory)
+        public static void Extend<T>(Func<string, SException, object, SException> factory)
         {
             Extend(typeof(T), factory);
         }
@@ -117,24 +118,24 @@ namespace CatLib.Support
         /// <param name="exception">The type of exception.</param>
         /// <param name="factory">The exception factory.</param>
         [System.Diagnostics.DebuggerNonUserCode]
-        public static void Extend(Type exception, Func<string, Exception, object, Exception> factory)
+        public static void Extend(Type exception, Func<string, SException, object, SException> factory)
         {
             VerfiyExceptionFactory();
             exceptionFactory[exception] = factory;
         }
 
-        private static Exception CreateExceptionInstance(Type exceptionType, string message, Exception innerException, object state)
+        private static SException CreateExceptionInstance(Type exceptionType, string message, SException innerException, object state)
         {
-            if (!typeof(Exception).IsAssignableFrom(exceptionType))
+            if (!typeof(SException).IsAssignableFrom(exceptionType))
             {
                 throw new ArgumentException(
-                    $"Type: {exceptionType} must be inherited from: {typeof(Exception)}.",
+                    $"Type: {exceptionType} must be inherited from: {typeof(SException)}.",
                     nameof(exceptionType));
             }
 
             VerfiyExceptionFactory();
 
-            if (exceptionFactory.TryGetValue(exceptionType, out Func<string, Exception, object, Exception> factory))
+            if (exceptionFactory.TryGetValue(exceptionType, out Func<string, SException, object, SException> factory))
             {
                 return factory(message, innerException, state);
             }
@@ -150,14 +151,14 @@ namespace CatLib.Support
                 SetField(exception, "_innerException", innerException);
             }
 
-            return (Exception)exception;
+            return (SException)exception;
         }
 
         private static void VerfiyExceptionFactory()
         {
             if (exceptionFactory == null)
             {
-                exceptionFactory = new Dictionary<Type, Func<string, Exception, object, Exception>>();
+                exceptionFactory = new Dictionary<Type, Func<string, SException, object, SException>>();
             }
         }
 

--- a/src/CatLib.Core/Support/Stream/CombineStream.cs
+++ b/src/CatLib.Core/Support/Stream/CombineStream.cs
@@ -9,6 +9,7 @@
  * Document: https://catlib.io/
  */
 
+using CatLib.Exception;
 using System;
 using System.IO;
 

--- a/src/CatLib.Core/Support/Stream/RingBufferStream.cs
+++ b/src/CatLib.Core/Support/Stream/RingBufferStream.cs
@@ -9,6 +9,7 @@
  * Document: https://catlib.io/
  */
 
+using CatLib.Exception;
 using System;
 using System.IO;
 


### PR DESCRIPTION
| Q | A |
|----|----|
| Branch? |  v2.0(master)  |
| Bug fix? | No |
| New feature? | No |
| Deprecations? | No |
| Internal Changed? | Yes |
| Removed | No |
| Tests pass? | No |
| Doc pr? | No |

The commit moved the Exception namespace, Moved from `CatLib.Support` to `CatLib.Exception`