### PR TITLE
Facade.Instance rename to Facade.That

### DIFF
--- a/src/CatLib.Core.Tests/CatLib/TestsFacade.cs
+++ b/src/CatLib.Core.Tests/CatLib/TestsFacade.cs
@@ -31,20 +31,20 @@ namespace CatLib.Tests
         public void TestFacade()
         {
             application.Singleton<IFoo, Foo>();
-            var foo = Facade<IFoo>.Instance;
+            var foo = Facade<IFoo>.That;
 
-            Assert.AreSame(foo, Facade<IFoo>.Instance);
+            Assert.AreSame(foo, Facade<IFoo>.That);
         }
 
         [TestMethod]
         public void TestAlwaysWatchNewer()
         {
             application.Singleton<IFoo, Foo>();
-            var older = Facade<IFoo>.Instance;
+            var older = Facade<IFoo>.That;
 
             application.Unbind<IFoo>();
             application.Singleton<IFoo, Foo>();
-            var newer = Facade<IFoo>.Instance;
+            var newer = Facade<IFoo>.That;
 
             Assert.AreNotSame(older, newer);
         }
@@ -53,11 +53,11 @@ namespace CatLib.Tests
         public void TestAlwaysWatchWithInstance()
         {
             application.Singleton<IFoo, Foo>();
-            Assert.AreNotEqual(null, Facade<IFoo>.Instance);
+            Assert.AreNotEqual(null, Facade<IFoo>.That);
 
             var foo = new Foo();
             application.Instance<IFoo>(foo);
-            Assert.AreSame(foo, Facade<IFoo>.Instance);
+            Assert.AreSame(foo, Facade<IFoo>.That);
         }
 
         [TestMethod]
@@ -65,10 +65,10 @@ namespace CatLib.Tests
         public void TestFacadeMakeFaild()
         {
             application.Singleton<IFoo, Foo>();
-            Assert.AreNotEqual(null, Facade<IFoo>.Instance);
+            Assert.AreNotEqual(null, Facade<IFoo>.That);
 
             application.Unbind<IFoo>();
-            _ = Facade<IFoo>.Instance;
+            _ = Facade<IFoo>.That;
         }
 
         [TestMethod]
@@ -76,11 +76,11 @@ namespace CatLib.Tests
         {
             application.Singleton<IFoo, Foo>();
 
-            var foo = Facade<IFoo>.Instance;
-            Assert.AreSame(foo, Facade<IFoo>.Instance);
+            var foo = Facade<IFoo>.That;
+            Assert.AreSame(foo, Facade<IFoo>.That);
 
             application.Release<IFoo>();
-            Assert.AreNotSame(foo, Facade<IFoo>.Instance);
+            Assert.AreNotSame(foo, Facade<IFoo>.That);
         }
 
         [TestMethod]
@@ -88,8 +88,8 @@ namespace CatLib.Tests
         {
             application.Bind<IFoo, Foo>();
 
-            var foo = Facade<IFoo>.Instance;
-            Assert.AreNotSame(foo, Facade<IFoo>.Instance);
+            var foo = Facade<IFoo>.That;
+            Assert.AreNotSame(foo, Facade<IFoo>.That);
         }
 
         [TestMethod]
@@ -97,14 +97,14 @@ namespace CatLib.Tests
         {
             application.Singleton<IFoo, Foo>();
 
-            var foo = Facade<IFoo>.Instance;
-            Assert.AreSame(foo, Facade<IFoo>.Instance);
+            var foo = Facade<IFoo>.That;
+            Assert.AreSame(foo, Facade<IFoo>.That);
 
             application.Unbind<IFoo>();
             application.Bind<IFoo, Foo>();
 
-            Assert.AreNotSame(foo, Facade<IFoo>.Instance);
-            Assert.AreNotSame(Facade<IFoo>.Instance, Facade<IFoo>.Instance);
+            Assert.AreNotSame(foo, Facade<IFoo>.That);
+            Assert.AreNotSame(Facade<IFoo>.That, Facade<IFoo>.That);
         }
 
         [TestMethod]
@@ -112,14 +112,14 @@ namespace CatLib.Tests
         {
             application.Bind<IFoo, Foo>();
 
-            var foo = Facade<IFoo>.Instance;
-            Assert.AreNotSame(foo, Facade<IFoo>.Instance);
+            var foo = Facade<IFoo>.That;
+            Assert.AreNotSame(foo, Facade<IFoo>.That);
 
             application.Unbind<IFoo>();
             application.Singleton<IFoo, Foo>();
 
-            Assert.AreNotSame(foo, Facade<IFoo>.Instance);
-            Assert.AreSame(Facade<IFoo>.Instance, Facade<IFoo>.Instance);
+            Assert.AreNotSame(foo, Facade<IFoo>.That);
+            Assert.AreSame(Facade<IFoo>.That, Facade<IFoo>.That);
         }
 
         [TestMethod]
@@ -127,8 +127,8 @@ namespace CatLib.Tests
         {
             application.Instance<IFoo>(new Foo());
 
-            var foo = Facade<IFoo>.Instance;
-            Assert.AreSame(foo, Facade<IFoo>.Instance);
+            var foo = Facade<IFoo>.That;
+            Assert.AreSame(foo, Facade<IFoo>.That);
         }
     }
 }

--- a/src/CatLib.Core/CatLib/App.cs
+++ b/src/CatLib.Core/CatLib/App.cs
@@ -29,7 +29,7 @@ namespace CatLib
         /// <summary>
         /// The <see cref="IApplication"/> instance.
         /// </summary>
-        private static IApplication instance;
+        private static IApplication that;
 
         /// <summary>
         /// Callback when a new <see cref="IApplication"/> instance is created.
@@ -39,9 +39,9 @@ namespace CatLib
             add
             {
                 RaiseOnNewApplication += value;
-                if (instance != null)
+                if (That != null)
                 {
-                    value?.Invoke(instance);
+                    value?.Invoke(That);
                 }
             }
             remove => RaiseOnNewApplication -= value;
@@ -59,13 +59,13 @@ namespace CatLib
         {
             get
             {
-                return instance;
+                return that;
             }
 
             set
             {
-                instance = value;
-                RaiseOnNewApplication?.Invoke(instance);
+                that = value;
+                RaiseOnNewApplication?.Invoke(that);
             }
         }
 

--- a/src/CatLib.Core/CatLib/Facade.cs
+++ b/src/CatLib.Core/CatLib/Facade.cs
@@ -109,7 +109,7 @@ namespace CatLib
                 return;
             }
 
-            Facade<TService>.that = default(TService);
+            that = default(TService);
             released = true;
         }
 

--- a/src/CatLib.Core/CatLib/Facade.cs
+++ b/src/CatLib.Core/CatLib/Facade.cs
@@ -27,7 +27,7 @@ namespace CatLib
     public abstract class Facade<TService>
     {
         private static readonly string Service;
-        private static TService instance;
+        private static TService that;
         private static IBindData binder;
         private static bool inited;
         private static bool released;
@@ -42,21 +42,21 @@ namespace CatLib
             Service = App.Type2Service(typeof(TService));
             App.OnNewApplication += app =>
             {
-                instance = default(TService);
+                that = default(TService);
                 binder = null;
                 inited = false;
                 released = false;
             };
         }
 
-        /// <inheritdoc cref="instance"/>
-        public static TService Instance => HasInstance ? instance : Resolve();
+        /// <inheritdoc cref="that"/>
+        public static TService That => HasInstance ? that : Resolve();
 
         /// <summary>
         /// Gets a value indicating whether the resolved instance is exists in the facade.
         /// <para>If it is a non-static binding then return forever false.</para>
         /// </summary>
-        internal static bool HasInstance => binder != null && binder.IsStatic && !released && instance != null;
+        internal static bool HasInstance => binder != null && binder.IsStatic && !released && that != null;
 
         /// <summary>
         /// Resolve the object instance.
@@ -65,7 +65,7 @@ namespace CatLib
         /// <returns>The resolved object.</returns>
         internal static TService Make(params object[] userParams)
         {
-            return HasInstance ? instance : Resolve(userParams);
+            return HasInstance ? that : Resolve(userParams);
         }
 
         /// <inheritdoc cref="Make"/>
@@ -94,7 +94,7 @@ namespace CatLib
             }
 
             Rebind(newBinder);
-            return instance = Build(userParams);
+            return that = Build(userParams);
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace CatLib
                 return;
             }
 
-            Facade<TService>.instance = default(TService);
+            Facade<TService>.that = default(TService);
             released = true;
         }
 
@@ -121,7 +121,7 @@ namespace CatLib
         {
             var newBinder = App.GetBind(Service);
             Rebind(newBinder);
-            instance = (newBinder == null || !newBinder.IsStatic) ? default(TService) : newService;
+            that = (newBinder == null || !newBinder.IsStatic) ? default(TService) : newService;
         }
 
         /// <summary>


### PR DESCRIPTION
| Q | A |
|----|----|
| Branch? |  v2.0(master)  |
| Bug fix? | No |
| New feature? | No |
| Deprecations? | No |
| Internal Changed? | Yes |
| Removed | No |
| Tests pass? | Yes |
| Doc pr? | No |

Renamed Facade.Instance to Facade.That. Also corrected some internal variable naming.