### PR TITLE
Removed global params in application constructor.

### DIFF
--- a/src/CatLib.Core.Tests/CatLib/TestsFacade.cs
+++ b/src/CatLib.Core.Tests/CatLib/TestsFacade.cs
@@ -23,7 +23,7 @@ namespace CatLib.Tests
         [TestInitialize]
         public void Initialize()
         {
-            application = new Application();
+            application = Application.New();
             application.Bootstrap();
         }
 

--- a/src/CatLib.Core/CatLib/Application.cs
+++ b/src/CatLib.Core/CatLib/Application.cs
@@ -42,7 +42,7 @@ namespace CatLib
         /// Initializes a new instance of the <see cref="Application"/> class.
         /// </summary>
         /// <param name="global">True if sets the instance to <see cref="App"/> facade.</param>
-        public Application(bool global = true)
+        public Application()
         {
             loadedProviders = new List<IServiceProvider>();
 
@@ -70,11 +70,6 @@ namespace CatLib
 
             DebugLevel = DebugLevel.Production;
             Process = StartProcess.Construct;
-
-            if (global)
-            {
-                App.That = this;
-            }
         }
 
         /// <summary>
@@ -106,7 +101,13 @@ namespace CatLib
         /// <returns>The CatLib <see cref="Application"/> instance.</returns>
         public static Application New(bool global = true)
         {
-            return new Application(global);
+            var application = new Application();
+            if (global)
+            {
+                App.That = application;
+            }
+
+            return application;
         }
 
         /// <summary>


### PR DESCRIPTION
| Q | A |
|----|----|
| Branch? |  v2.0(master)  |
| Bug fix? | No |
| New feature? | No |
| Deprecations? | No |
| Internal Changed? | Yes |
| Removed | No |
| Tests pass? | Yes |
| Doc pr? | No |

this commit removed `global` params in application constructor.  use `Application.New()` instead.