### PR TITLE
Container is not thread-safe by default.

### DIFF
--- a/src/CatLib.Core/Container/BindData.cs
+++ b/src/CatLib.Core/Container/BindData.cs
@@ -58,25 +58,21 @@ namespace CatLib.Container
         /// <inheritdoc />
         public IBindData Alias(string alias)
         {
-            lock (Locker)
-            {
-                AssertDestroyed();
-                Guard.ParameterNotNull(alias, nameof(alias));
-                Container.Alias(alias, Service);
-                return this;
-            }
+            AssertDestroyed();
+            Guard.ParameterNotNull(alias, nameof(alias));
+
+            Container.Alias(alias, Service);
+            return this;
         }
 
         /// <inheritdoc />
         public IBindData Tag(string tag)
         {
-            lock (Locker)
-            {
-                AssertDestroyed();
-                Guard.ParameterNotNull(tag, nameof(tag));
-                Container.Tag(tag, Service);
-                return this;
-            }
+            AssertDestroyed();
+            Guard.ParameterNotNull(tag, nameof(tag));
+
+            Container.Tag(tag, Service);
+            return this;
         }
 
         /// <inheritdoc />
@@ -127,21 +123,17 @@ namespace CatLib.Container
             ((CatLibContainer)Container).Unbind(this);
         }
 
-        private void AddClosure(Action<IBindData, object> closure, ref List<Action<IBindData, object>> list)
+        private void AddClosure(Action<IBindData, object> closure, ref List<Action<IBindData, object>> collection)
         {
             Guard.Requires<ArgumentNullException>(closure != null);
+            AssertDestroyed();
 
-            lock (Locker)
+            if (collection == null)
             {
-                AssertDestroyed();
-
-                if (list == null)
-                {
-                    list = new List<Action<IBindData, object>>();
-                }
-
-                list.Add(closure);
+                collection = new List<Action<IBindData, object>>();
             }
+
+            collection.Add(closure);
         }
     }
 }


### PR DESCRIPTION
| Q | A |
|----|----|
| Branch? |  v2.0(master)  |
| Bug fix? | No |
| New feature? | No |
| Deprecations? | No |
| Internal Changed? | Yes |
| Removed | No |
| Tests pass? | Yes |
| Doc pr? | No |

Containers are no longer thread-safe by default. Because in most cases we don't need thread safety, and existing thread safety can make the code messy.