### PR TITLE
Enhance ExpectedExceptionAndMessageAttribute to support asterisk wildcard.

### DIFF
--- a/src/CatLib.Core.Tests/CatLib/TestsApplication.cs
+++ b/src/CatLib.Core.Tests/CatLib/TestsApplication.cs
@@ -118,7 +118,7 @@ namespace CatLib.Tests
         }
 
         [TestMethod]
-        [ExpectedExceptionAndMessage(typeof(LogicException))]
+        [ExpectedException(typeof(LogicException))]
         public void TestInitingRegister()
         {
             var foo = new Mock<IServiceProvider>();
@@ -135,7 +135,7 @@ namespace CatLib.Tests
         }
 
         [TestMethod]
-        [ExpectedExceptionAndMessage(typeof(LogicException))]
+        [ExpectedException(typeof(LogicException))]
         public void TestTerminateRegister()
         {
             var foo = new Mock<IServiceProvider>();

--- a/src/CatLib.Core.Tests/Container/TestsContainer.cs
+++ b/src/CatLib.Core.Tests/Container/TestsContainer.cs
@@ -560,7 +560,7 @@ namespace CatLib.Tests.Container
         }
 
         [TestMethod]
-        [ExpectedExceptionAndMessage(typeof(TestException), "QuuxFoo")]
+        [ExpectedExceptionAndMessage(typeof(UnresolvableException), "QuuxFoo")]
         public void TestMakeConstructorThrowException()
         {
             container.Bind("foo", typeof(QuuxFoo), false);


### PR DESCRIPTION
The commit allows wildcarding with asterisk wildcards in exception assertion attributes.

Fixed a buggy design, exception assertions should check the exception itself and should not detect internal exceptions.

resolved #285 